### PR TITLE
Make the tests compatible with WSL

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,24 +1,34 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-#include(FetchContent)
 
-#set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-#FetchContent_Declare(
-#    googletest
-#    GIT_REPOSITORY https://github.com/google/googletest.git
-#    GIT_TAG main # Live at head
-#)
-#FetchContent_MakeAvailable(googletest)
+# Assume to use vcpkg to install gtest
+list(APPEND gtestlibs "")
+if("${CMAKE_TOOLCHAIN_FILE}" MATCHES "vcpkg.cmake$")
+  find_package(GTest CONFIG REQUIRED)
+  list(APPEND gtestlibs GTest::gtest_main)
+else()
+  include(FetchContent)
 
-find_package(GTest CONFIG REQUIRED)
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG main # Live at head
+  )
+  FetchContent_MakeAvailable(googletest)
+  list(APPEND gtestlibs gtest_main)
+endif()
 
 list(APPEND dxlibs "")
-if(EXISTS "/dev/dxg")
+if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
   find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
   find_library(libdxcore dxcore HINTS /lib/wsl/lib)
   list(APPEND dxlibs ${libd3d12} ${libdxcore})
+else()
+# Fallback to default: let CMake to looking for libs
+  list(APPEND dxlibs d3d12 dxcore)
 endif()
 
 project(DirectX-Headers-GoogleTest-Suite CXX)
 add_executable(Feature-Support-Test feature_support_test.cpp)
-target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main)
+target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} ${gtestlibs})

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,15 +1,24 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-include(FetchContent)
+#include(FetchContent)
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG main # Live at head
-)
-FetchContent_MakeAvailable(googletest)
+#set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+#FetchContent_Declare(
+#    googletest
+#    GIT_REPOSITORY https://github.com/google/googletest.git
+#    GIT_TAG main # Live at head
+#)
+#FetchContent_MakeAvailable(googletest)
+
+find_package(GTest CONFIG REQUIRED)
+
+list(APPEND dxlibs "")
+if(EXISTS "/dev/dxg")
+  find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
+  find_library(libdxcore dxcore HINTS /lib/wsl/lib)
+  list(APPEND dxlibs ${libd3d12} ${libdxcore})
+endif()
 
 project(DirectX-Headers-GoogleTest-Suite CXX)
 add_executable(Feature-Support-Test feature_support_test.cpp)
-target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids d3d12 dxcore gtest_main)
+target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} GTest::gmock GTest::gtest GTest::gmock_main GTest::gtest_main)

--- a/googletest/MockDevice.hpp
+++ b/googletest/MockDevice.hpp
@@ -391,6 +391,7 @@ public: // ID3D12Object
     }
 
 public: // IUnknown
+#ifdef _WIN32
     virtual HRESULT STDMETHODCALLTYPE QueryInterface(
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject) override
@@ -398,6 +399,15 @@ public: // IUnknown
         *ppvObject = this;
         return S_OK;
     }
+#else
+    virtual HRESULT STDMETHODCALLTYPE QueryInterface(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void **ppvObject)
+    {
+        *ppvObject = this;
+        return S_OK;
+    }
+#endif
 
     virtual ULONG STDMETHODCALLTYPE AddRef() override 
     {
@@ -502,7 +512,7 @@ public: // IUnknown
             default:
                 return E_INVALIDARG;
             }
-            pRootSig->HighestVersion = min(pRootSig->HighestVersion, m_RootSignatureHighestVersion); 
+            pRootSig->HighestVersion = std::min(pRootSig->HighestVersion, m_RootSignatureHighestVersion); 
         } return S_OK;
         
 
@@ -699,7 +709,7 @@ public: // IUnknown
                 default:
                     return E_INVALIDARG;
                 }
-                pSM->HighestShaderModel = min(pSM->HighestShaderModel,m_HighestSupportedShaderModel);
+                pSM->HighestShaderModel = std::min(pSM->HighestShaderModel,m_HighestSupportedShaderModel);
             } return S_OK;
         case D3D12_FEATURE_SHADER_CACHE:
             {

--- a/googletest/MockDevice.hpp
+++ b/googletest/MockDevice.hpp
@@ -4,6 +4,10 @@
 #define DIRECTX_HEADERS_MOCK_DEVICE_HPP
 #include <unordered_map>
 
+#ifndef __RPC_FAR
+#define __RPC_FAR
+#endif
+
 #include <directx/d3d12.h>
 #include <directx/dxcore.h>
 #include <directx/d3dx12.h>
@@ -391,7 +395,6 @@ public: // ID3D12Object
     }
 
 public: // IUnknown
-#ifdef _WIN32
     virtual HRESULT STDMETHODCALLTYPE QueryInterface(
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject) override
@@ -399,15 +402,6 @@ public: // IUnknown
         *ppvObject = this;
         return S_OK;
     }
-#else
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(
-        /* [in] */ REFIID riid,
-        /* [iid_is][out] */ _COM_Outptr_ void **ppvObject)
-    {
-        *ppvObject = this;
-        return S_OK;
-    }
-#endif
 
     virtual ULONG STDMETHODCALLTYPE AddRef() override 
     {

--- a/googletest/feature_support_test.cpp
+++ b/googletest/feature_support_test.cpp
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 #include "gtest/gtest.h"
 
+#ifndef _WIN32
+#include <wsl/winadapter.h>
+#endif
+
 #include <directx/d3d12.h>
 #include <directx/dxcore.h>
 #include <directx/d3dx12.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,10 +2,14 @@
 # Licensed under the MIT License.
 
 list(APPEND dxlibs "")
-if(EXISTS "/dev/dxg")
+# Check if in WSL and if has DirectX driver and runtime
+if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
   find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
   find_library(libdxcore dxcore HINTS /lib/wsl/lib)
   list(APPEND dxlibs ${libd3d12} ${libdxcore})
+else()
+# Fallback to default: let CMake to looking for libs
+  list(APPEND dxlibs d3d12 dxcore)
 endif()
 
 project(DirectX-Headers-Test CXX)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+list(APPEND dxlibs "")
+if(EXISTS "/dev/dxg")
+  find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
+  find_library(libdxcore dxcore HINTS /lib/wsl/lib)
+  list(APPEND dxlibs ${libd3d12} ${libdxcore})
+endif()
+
 project(DirectX-Headers-Test CXX)
 add_executable(DirectX-Headers-Test test.cpp)
-target_link_libraries(DirectX-Headers-Test DirectX-Headers DirectX-Guids d3d12 dxcore)
+target_link_libraries(DirectX-Headers-Test DirectX-Headers DirectX-Guids ${dxlibs})
 
 add_executable(DirectX-Headers-Check-Feature-Support-Test feature_check_test.cpp)
-target_link_libraries(DirectX-Headers-Check-Feature-Support-Test DirectX-Headers DirectX-Guids d3d12 dxcore)
+target_link_libraries(DirectX-Headers-Check-Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs})

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -97,7 +97,9 @@ std::cout << "Verification failed: " << #FeatureName << std::endl \
 // -----------------------------------------------------------------------------------------------------------------
 // Main function
 // -----------------------------------------------------------------------------------------------------------------
-int main()
+using namespace Microsoft::WRL;
+
+int run_main(IUnknown* adapter)
 {
     ID3D12Device *device = nullptr;
 
@@ -631,5 +633,50 @@ int main()
     }
 
     std::cout << "Test completed with no errors." << std::endl;
+    return 0;
+}
+
+// Helper utility converts D3D API failures into exceptions.
+inline void ThrowIfFailed(HRESULT hr) noexcept(false) {
+    if (FAILED(hr)) {
+        throw std::runtime_error("");
+    }
+}
+
+std::vector<char> get_property(ComPtr<IDXCoreAdapter> _adapter, DXCoreAdapterProperty property) {
+    if (_adapter->IsPropertySupported(property)) {
+        size_t len;
+        ThrowIfFailed(_adapter->GetPropertySize(property, &len));
+        std::vector<char> buf(len);
+        ThrowIfFailed(_adapter->GetProperty(property, len, buf.data()));
+        return buf;
+    }
+    return {};
+}
+
+std::string get_driver_description(ComPtr<IDXCoreAdapter> _adapter) {
+    auto rs = get_property(_adapter, DXCoreAdapterProperty::DriverDescription);
+    std::string name(rs.data());
+    return name;
+}
+
+int main()
+{
+    ComPtr<IDXCoreAdapterFactory> d3d_adapter_factory;
+    ComPtr<IDXCoreAdapterList> d3d_adapter_list;
+    GUID dx_must_attr[1]{ DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
+    bool dx_must_hardware{ true };
+    ThrowIfFailed(DXCoreCreateAdapterFactory(IID_PPV_ARGS(&d3d_adapter_factory)));
+    ThrowIfFailed(d3d_adapter_factory->CreateAdapterList(_countof(dx_must_attr), dx_must_attr,
+        IID_PPV_ARGS(&d3d_adapter_list)));
+    const uint32_t count{ d3d_adapter_list->GetAdapterCount() };
+
+    // Generate all devices object;
+    for (uint32_t i = 0; i < count; i++) {
+        ComPtr<IDXCoreAdapter> d3d_adapter;
+        ThrowIfFailed(d3d_adapter_list->GetAdapter(i, IID_PPV_ARGS(&d3d_adapter)));
+        std::cout << "--------------- Device: " << get_driver_description(d3d_adapter) <<" ---------------" << std::endl;
+        ThrowIfFailed(run_main(d3d_adapter.Get()));
+    }
     return 0;
 }

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -103,7 +103,7 @@ int run_main(IUnknown* adapter)
 {
     ID3D12Device *device = nullptr;
 
-    if (FAILED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device)))) 
+    if (FAILED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device)))) 
     {
         return -1;
     }


### PR DESCRIPTION
1. Changed CMakeLists.txt in test/ and googletest/ to make it easier to find libd3d12.so and libdxcore.so in WSL;
2. Changed main function in test/feature_check_test.cpp to support enumeration of all supported adapters;
3. Fix OS specific problem for test under googletest/;